### PR TITLE
Summary formatter bugfixes

### DIFF
--- a/src/components/SummaryFormatter.tsx
+++ b/src/components/SummaryFormatter.tsx
@@ -16,9 +16,9 @@ function formatText(text: string, isList: boolean) {
     // let inList = false;
     //replace all Latex with '__latex__'
     //make a regex to find all latex
-    console.log(text);
+    // console.log(text);
     // text = escapeString(text);
-    console.log(text);
+    // console.log(text);
     const jsxArray: JSX.Element[] = [];
     let latexArray: string[] = [];
     const latexRegex = /\$.*?\$/g;
@@ -31,7 +31,15 @@ function formatText(text: string, isList: boolean) {
     }
     //make into a list
     if (isList) {
-        const splitText = text.split("- ");
+        text = ' ' + text;
+        const splitText = text.split("-");
+        const emptyRegex = /^\s*$/;
+        for (const li of splitText) {
+            if(emptyRegex.test(li)){
+                splitText.splice(splitText.indexOf(li), 1);
+            }
+        }
+        console.log(`split text: ${splitText}`)
         splitText.forEach((line, index) => {
             jsxArray.push(<li key={index}>{line}</li>);
         });

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -16,6 +16,7 @@ interface Prompts {
 }
 
 const SummaryPanel = (props: Props) => {
+    const DEBUG = true;
     const [isOpen, setIsOpen] = useState(false);
     const LatexPrompt = " If there is any math whatsoever, use LaTeX notation to display it by enclosing it with two $ signs. Even single numbers should be in LaTeX for readability. ALL MATH SHOULD BE IN LATEX NOTATION."
     const prompts: Prompts = {
@@ -57,7 +58,7 @@ const SummaryPanel = (props: Props) => {
             //! fix this, it seems to be one button press behind
             //* I think a possible solution is to actually just return the response object from summarizeGPT and then set the state of the response object to the returned object
             await summarizeGPT(
-                false,
+                DEBUG,
                 prompts[activePrompt],
                 props.transcriptProp,
                 props.APIKeyProp

--- a/src/components/SummaryPanel.tsx
+++ b/src/components/SummaryPanel.tsx
@@ -16,7 +16,7 @@ interface Prompts {
 }
 
 const SummaryPanel = (props: Props) => {
-    const DEBUG = true;
+    const DEBUG = false;
     const [isOpen, setIsOpen] = useState(false);
     const LatexPrompt = " If there is any math whatsoever, use LaTeX notation to display it by enclosing it with two $ signs. Even single numbers should be in LaTeX for readability. ALL MATH SHOULD BE IN LATEX NOTATION."
     const prompts: Prompts = {

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -14,6 +14,8 @@ interface Props {
 }
 
 const TranscriptPanel = (props: Props) => {
+    const DEBUG = true;
+
     const [fileUploaded, setFileUploaded] = React.useState(false);
     const [audioFile, setAudioFile] = React.useState<File | null>(null);
     const [modalIsOpen, setModalIsOpen] = React.useState(false);
@@ -91,7 +93,7 @@ const TranscriptPanel = (props: Props) => {
         try {
             setIsLoading(true);
             if (doTranslate) {
-                await translateWhisper(false, audioFile, props.APIKeyProp).then(
+                await translateWhisper(DEBUG, audioFile, props.APIKeyProp).then(
                     (transcript) => {
                         console.log(transcript);
                         props.setTranscriptProp(transcript);
@@ -99,7 +101,7 @@ const TranscriptPanel = (props: Props) => {
                 );
             } else {
                 await transcribeWhisper(
-                    false,
+                    DEBUG,
                     audioFile,
                     "en",
                     props.APIKeyProp

--- a/src/components/TranscriptPanel.tsx
+++ b/src/components/TranscriptPanel.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const TranscriptPanel = (props: Props) => {
-    const DEBUG = true;
+    const DEBUG = false;
 
     const [fileUploaded, setFileUploaded] = React.useState(false);
     const [audioFile, setAudioFile] = React.useState<File | null>(null);

--- a/src/utils/summarize.ts
+++ b/src/utils/summarize.ts
@@ -23,7 +23,7 @@ export default async function summarizeGPT(
         // wait 3 seconds to simulate a long request
         await new Promise((resolve) => setTimeout(resolve, 3000));
         response.status = 200;
-        response.results[0] = `- Here is the weird latex that wasnt working: $\\sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2}$ and also $a + b = c$ - Also here is another bullet point - We will need a few of these - Hey, how about more LaTeX? Here is a sum: $\\sum_{n=1} ^{\\infty} a_i x^i$`;
+        response.results[0] = `- Here is the weird latex that wasnt working: $\\sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2}$ and also $a + b = c$ - Also here is another bullet point - Let's throw in a subtraction equation to be mean: $a - b = oh_{no}$ - We will need a few of these - Hey, how about more LaTeX? Here is a sum: $\\sum_{n=1} ^{\\infty} a_i x^i$`;
         // setResponse(response);
         return response;
     }

--- a/src/utils/summarize.ts
+++ b/src/utils/summarize.ts
@@ -23,7 +23,7 @@ export default async function summarizeGPT(
         // wait 3 seconds to simulate a long request
         await new Promise((resolve) => setTimeout(resolve, 3000));
         response.status = 200;
-        response.results[0] = `Here is the weird latex that wasnt working: $\\sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2}$ and also $a + b = c$`;
+        response.results[0] = `- Here is the weird latex that wasnt working: $\\sqrt{(x_1 - x_2)^2 + (y_1 - y_2)^2}$ and also $a + b = c$ - Also here is another bullet point - We will need a few of these - Hey, how about more LaTeX? Here is a sum: $\\sum_{n=1} ^{\\infty} a_i x^i$`;
         // setResponse(response);
         return response;
     }


### PR DESCRIPTION
I simply removed any empty elements from the split string array, and now the hanging bullet point at the beginning no longer appears.